### PR TITLE
Translate RFC9287.

### DIFF
--- a/1_Introduction/_index.md
+++ b/1_Introduction/_index.md
@@ -1,0 +1,22 @@
+---
+title: "1. 引言"
+anchor: "1_Introduction"
+weight: 100
+rank: "h1"
+---
+
+The version-independent definition of QUIC [QUIC-INVARIANTS] intentionally describes a very narrow set of fields that are visible to entities other than endpoints. Beyond those characteristics that are invariant, very little about the "wire image" [RFC8546] of QUIC is visible.
+
+在与版本无关的QUIC定义《[QUIC不变量]()》中描述了少量对于并非终端的实体可见的字段。除了那些不可变的特征外，QUIC的“线路图像”（`wire image`， 详见《[RFC8546]()》）几乎是不可见的。
+
+The second-most significant bit of the first byte in every QUIC packet is defined as having a fixed value in QUIC version 1 [QUIC]. The purpose of having a fixed value is to allow endpoints to efficiently distinguish QUIC from other protocols; see [DEMUX] for a description of a system that might use this property. As this bit can identify a packet as QUIC, it is sometimes referred to as the "QUIC Bit".
+
+在QUIC版本1中（详见《[QUIC]()》），所有QUIC数据包的首个字节的第二最高有效位被指定为固定值。设定该固定值的目的是为了与允许终端高效地将QUIC从其他协议中区分出来；有关可以利用该属性的系统的描述，详见《[DEMUX]()》。由于能够使用该比特位来辨识数据包是否为QUIC，因此它有时被称为“QUIC位”。
+
+Where endpoints and the intermediaries that support them do not depend on the QUIC Bit having a fixed value, sending the same value in every packet is more of a liability than an asset. If systems come to depend on a fixed value, then it might become infeasible to define a version of QUIC that attributes semantics to this bit.
+
+在支持QUIC的终端和中间设备并不要求QUIC位必须是固定值的情况下，在所有数据包中都使用相同的值的做法相比其好处，更多的是一种负担。相反，如果这些系统都依赖着固定值，那么就不可能再定义一个为该比特位添加语义的QUIC版本。
+
+In order to safeguard future use of this bit, this document defines a QUIC transport parameter that indicates that an endpoint is willing to receive QUIC packets containing any value for this bit. By sending different values for this bit, the hope is that the value will remain available for future use [USE-IT].
+
+为了保护该比特位将来的用途，本文档定义了一个QUIC传输参数，它能表明终端愿意接收该比特位被设置为其他值的QUIC数据包。通过释放对该比特位的限制，希望能够在将来随时利用该位的值（详见《[USE-IT]()》）。

--- a/1_Introduction/_index.md
+++ b/1_Introduction/_index.md
@@ -7,16 +7,21 @@ rank: "h1"
 
 The version-independent definition of QUIC [QUIC-INVARIANTS] intentionally describes a very narrow set of fields that are visible to entities other than endpoints. Beyond those characteristics that are invariant, very little about the "wire image" [RFC8546] of QUIC is visible.
 
-在与版本无关的QUIC定义《[QUIC不变量]()》中描述了少量对于并非终端的实体可见的字段。除了那些不可变的特征外，QUIC的“线路图像”（`wire image`， 详见《[RFC8546]()》）几乎是不可见的。
+在与版本无关的QUIC定义《[QUIC不变量]()》中描述了少量对于并非终端的实体可见的字段。
+除了那些不可变的特征外，QUIC的“线路图像”（`wire image`， 详见《[RFC8546]()》）几乎是不可见的。
 
 The second-most significant bit of the first byte in every QUIC packet is defined as having a fixed value in QUIC version 1 [QUIC]. The purpose of having a fixed value is to allow endpoints to efficiently distinguish QUIC from other protocols; see [DEMUX] for a description of a system that might use this property. As this bit can identify a packet as QUIC, it is sometimes referred to as the "QUIC Bit".
 
-在QUIC版本1中（详见《[QUIC]()》），所有QUIC数据包的首个字节的第二最高有效位被指定为固定值。设定该固定值的目的是为了与允许终端高效地将QUIC从其他协议中区分出来；有关可以利用该属性的系统的描述，详见《[DEMUX]()》。由于能够使用该比特位来辨识数据包是否为QUIC，因此它有时被称为“QUIC位”。
+在QUIC版本1中（详见《[QUIC]()》），所有QUIC数据包的首个字节的第二最高有效位被指定为固定值。
+设定该固定值的目的是为了与允许终端高效地将QUIC从其他协议中区分出来；有关可以利用该属性的系统的描述，详见《[DEMUX]()》。
+由于能够使用该比特位来辨识数据包是否为QUIC，因此它有时被称为“QUIC位”。
 
 Where endpoints and the intermediaries that support them do not depend on the QUIC Bit having a fixed value, sending the same value in every packet is more of a liability than an asset. If systems come to depend on a fixed value, then it might become infeasible to define a version of QUIC that attributes semantics to this bit.
 
-在支持QUIC的终端和中间设备并不要求QUIC位必须是固定值的情况下，在所有数据包中都使用相同的值的做法相比其好处，更多的是一种负担。相反，如果这些系统都依赖着固定值，那么就不可能再定义一个为该比特位添加语义的QUIC版本。
+在支持QUIC的终端和中间设备并不要求QUIC位必须是固定值的情况下，在所有数据包中都使用相同的值的做法相比其好处，更多的是一种负担。
+相反，如果这些系统都依赖着固定值，那么就不可能再定义一个为该比特位添加语义的QUIC版本。
 
 In order to safeguard future use of this bit, this document defines a QUIC transport parameter that indicates that an endpoint is willing to receive QUIC packets containing any value for this bit. By sending different values for this bit, the hope is that the value will remain available for future use [USE-IT].
 
-为了保护该比特位将来的用途，本文档定义了一个QUIC传输参数，它能表明终端愿意接收该比特位被设置为其他值的QUIC数据包。通过释放对该比特位的限制，希望能够在将来随时利用该位的值（详见《[USE-IT]()》）。
+为了保护该比特位将来的用途，本文档定义了一个QUIC传输参数，它能表明终端愿意接收该比特位被设置为其他值的QUIC数据包。
+通过释放对该比特位的限制，希望能够在将来随时利用该位的值（详见《[USE-IT]()》）。

--- a/1_Introduction/_index.md
+++ b/1_Introduction/_index.md
@@ -8,7 +8,7 @@ rank: "h1"
 The version-independent definition of QUIC [QUIC-INVARIANTS] intentionally describes a very narrow set of fields that are visible to entities other than endpoints. Beyond those characteristics that are invariant, very little about the "wire image" [RFC8546] of QUIC is visible.
 
 在与版本无关的QUIC定义《[QUIC不变量]()》中描述了少量对于并非终端的实体可见的字段。
-除了那些不可变的特征外，QUIC的“线路图像”（`wire image`， 详见《[RFC8546]()》）几乎是不可见的。
+除了那些不可变的特征外，QUIC的“通信数据映像”（`wire image`， 详见《[RFC8546]()》）几乎是不可见的。
 
 The second-most significant bit of the first byte in every QUIC packet is defined as having a fixed value in QUIC version 1 [QUIC]. The purpose of having a fixed value is to allow endpoints to efficiently distinguish QUIC from other protocols; see [DEMUX] for a description of a system that might use this property. As this bit can identify a packet as QUIC, it is sometimes referred to as the "QUIC Bit".
 

--- a/1_Introduction/_index.md
+++ b/1_Introduction/_index.md
@@ -5,23 +5,15 @@ weight: 100
 rank: "h1"
 ---
 
-The version-independent definition of QUIC [QUIC-INVARIANTS] intentionally describes a very narrow set of fields that are visible to entities other than endpoints. Beyond those characteristics that are invariant, very little about the "wire image" [RFC8546] of QUIC is visible.
-
 在与版本无关的QUIC定义《[QUIC不变量]()》中描述了少量对于并非终端的实体可见的字段。
 除了那些不可变的特征外，QUIC的“通信数据映像”（`wire image`， 详见《[RFC8546]()》）几乎是不可见的。
-
-The second-most significant bit of the first byte in every QUIC packet is defined as having a fixed value in QUIC version 1 [QUIC]. The purpose of having a fixed value is to allow endpoints to efficiently distinguish QUIC from other protocols; see [DEMUX] for a description of a system that might use this property. As this bit can identify a packet as QUIC, it is sometimes referred to as the "QUIC Bit".
 
 在QUIC版本1中（详见《[QUIC]()》），所有QUIC数据包的首个字节的第二最高有效位被指定为固定值。
 设定该固定值的目的是为了与允许终端高效地将QUIC从其他协议中区分出来；有关可以利用该属性的系统的描述，详见《[DEMUX]()》。
 由于能够使用该比特位来辨识数据包是否为QUIC，因此它有时被称为“QUIC位”。
 
-Where endpoints and the intermediaries that support them do not depend on the QUIC Bit having a fixed value, sending the same value in every packet is more of a liability than an asset. If systems come to depend on a fixed value, then it might become infeasible to define a version of QUIC that attributes semantics to this bit.
-
 在支持QUIC的终端和中间设备并不要求QUIC位必须是固定值的情况下，在所有数据包中都使用相同的值的做法相比其好处，更多的是一种负担。
 相反，如果这些系统都依赖着固定值，那么就不可能再定义一个为该比特位添加语义的QUIC版本。
-
-In order to safeguard future use of this bit, this document defines a QUIC transport parameter that indicates that an endpoint is willing to receive QUIC packets containing any value for this bit. By sending different values for this bit, the hope is that the value will remain available for future use [USE-IT].
 
 为了保护该比特位将来的用途，本文档定义了一个QUIC传输参数，它能表明终端愿意接收该比特位被设置为其他值的QUIC数据包。
 通过释放对该比特位的限制，希望能够在将来随时利用该位的值（详见《[USE-IT]()》）。

--- a/2_Conventions_and_Definitions/_index.md
+++ b/2_Conventions_and_Definitions/_index.md
@@ -5,10 +5,6 @@ weight: 200
 rank: "h1"
 ---
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119] [RFC8174] when, and only when, they appear in all capitals, as shown here.
-
 本文中的关键字“{{< req_level MUST >}}（**MUST**）”、“{{< req_level MUST_NOT >}}（**MUST NOT**）”、“{{< req_level REQUIRED >}}（**REQUIRED**）”、“{{< req_level SHALL >}}（**SHALL**）”、“{{< req_level SHALL_NOT >}}（**SHALL NOT**）”、“{{< req_level SHOULD >}}（**SHOULD**）”、“{{< req_level SHOULD_NOT >}}（**SHOULD NOT**）”、“{{< req_level RECOMMENDED >}}（**RECOMMENDED**）”、“{{< req_level NOT_RECOMMENDED >}}（**NOT RECOMMENDED**）”、“{{< req_level MAY >}}（**MAY**）”，以及“{{< req_level OPTIONAL >}}（**OPTIONAL**）”应理解为BCP 14 《[RFC2119](https://www.rfc-editor.org/info/rfc2119)》《[RFC8174](https://www.rfc-editor.org/info/rfc8174)》所描述的，当且仅当它们像本段一样以斜体加粗方式出现的时候。
-
-This document uses terms and notational conventions from [QUIC].
 
 本文使用了来自《[QUIC]()》的术语和标记上的约定。

--- a/2_Conventions_and_Definitions/_index.md
+++ b/2_Conventions_and_Definitions/_index.md
@@ -1,0 +1,14 @@
+---
+title: "2. 约定与定义"
+anchor: "2_Conventions_and_Definitions"
+weight: 200
+rank: "h1"
+---
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119] [RFC8174] when, and only when, they appear in all capitals, as shown here.
+
+本文中的关键字“{{< req_level MUST >}}（**MUST**）”、“{{< req_level MUST_NOT >}}（**MUST NOT**）”、“{{< req_level REQUIRED >}}（**REQUIRED**）”、“{{< req_level SHALL >}}（**SHALL**）”、“{{< req_level SHALL_NOT >}}（**SHALL NOT**）”、“{{< req_level SHOULD >}}（**SHOULD**）”、“{{< req_level SHOULD_NOT >}}（**SHOULD NOT**）”、“{{< req_level RECOMMENDED >}}（**RECOMMENDED**）”、“{{< req_level NOT_RECOMMENDED >}}（**NOT RECOMMENDED**）”、“{{< req_level MAY >}}（**MAY**）”，以及“{{< req_level OPTIONAL >}}（**OPTIONAL**）”应理解为BCP 14 《[RFC2119](https://www.rfc-editor.org/info/rfc2119)》《[RFC8174](https://www.rfc-editor.org/info/rfc8174)》所描述的，当且仅当它们像本段一样以斜体加粗方式出现的时候。
+
+This document uses terms and notational conventions from [QUIC].
+
+本文使用了来自《[QUIC]()》的术语和标记上的约定。

--- a/3_The_Grease_QUIC_Bit_Transport_Parameter/3.1_Clearing_the_QUIC_Bit.md
+++ b/3_The_Grease_QUIC_Bit_Transport_Parameter/3.1_Clearing_the_QUIC_Bit.md
@@ -11,20 +11,25 @@ Endpoints that receive the grease_quic_bit transport parameter from a peer SHOUL
 
 Endpoints can set the QUIC Bit to 0 on all packets that are sent after receiving and processing transport parameters. This could include Initial, Handshake, and Retry packets.
 
-终端可以将所有在接收并处理完传输参数后发送的数据包的QUIC位设置为`0`。其中可能包括初始数据包、握手数据包和重试数据包。
+终端可以将所有在接收并处理完传输参数后发送的数据包的QUIC位设置为`0`。
+其中可能包括初始数据包、握手数据包和重试数据包。
 
 A client MAY also set the QUIC Bit to 0 in Initial, Handshake, or 0-RTT packets that are sent prior to receiving transport parameters from the server. However, a client MUST NOT set the QUIC Bit to 0 unless the Initial packets it sends include a token provided by the server in a NEW_TOKEN frame (Section 19.7 of [QUIC]), received less than 604800 seconds (7 days) prior on a connection where the server also included the grease_quic_bit transport parameter.
 
-客户端还**可以**在从服务器接收到传输参数前就将发送出去的初始数据包、握手数据包或0-RTT数据包的QUIC位设置为`0`。不过，只有在客户端发送的初始数据包中包含了服务器在**新令牌帧**（详见《[QUIC]()》的[第19.7章]()）中提供的令牌，且这个帧是在过去604800秒（7天）内，在一条服务器使用了传输参数`grease_quic_bit`的连接上接收到的时，它才可以这么做。
+客户端还**可以**在从服务器接收到传输参数前就将发送出去的初始数据包、握手数据包或0-RTT数据包的QUIC位设置为`0`。
+不过，只有在客户端发送的初始数据包中包含了服务器在**新令牌帧**（详见《[QUIC]()》的[第19.7章]()）中提供的令牌，且这个帧是在过去604800秒（7天）内，在一条服务器使用了传输参数`grease_quic_bit`的连接上接收到的时，它才可以这么做。
 
 This 7-day limit allows for changes in server configuration. If server configuration changes and a client does not set the QUIC Bit, then it is possible that a server will drop packets, resulting in connection failures.
 
-这个7天的时限容许服务器的配置发生变化。如果服务器改变了配置且客户端没有设置QUIC位，那么服务器有可能丢弃数据包，使得连接失败。
+这个7天的时限容许服务器的配置发生变化。
+如果服务器改变了配置且客户端没有设置QUIC位，那么服务器有可能丢弃数据包，使得连接失败。
 
 A server MUST set the QUIC Bit to 0 only after processing transport parameters from a client. A server MUST NOT remember that a client negotiated the extension in a previous connection and set the QUIC Bit to 0 based on that information.
 
-服务器**必须**仅在处理完来自客户端的传输参数后再将QUIC位设置为`0`。服务器**必须不**记忆客户端在先前的连接中协商的扩展，或基于该信息来将QUIC位设置为`0`。
+服务器**必须**仅在处理完来自客户端的传输参数后再将QUIC位设置为`0`。
+服务器**必须不**记忆客户端在先前的连接中协商的扩展，或基于该信息来将QUIC位设置为`0`。
 
 An endpoint MUST NOT set the QUIC Bit to 0 without knowing whether the peer supports the extension. As Stateless Reset packets (Section 10.3 of [QUIC]) are only used after a loss of connection state, endpoints are unlikely to be able to set the QUIC Bit to 0 on Stateless Reset packets.
 
-终端在不了解对端是否支持本扩展的情况下**必须不**将QUIC位设置为`0`。由于无状态重置数据包（详见《[QUIC]()》的[第10.3章]()）仅会在连接状态丢失后才被使用，所以终端不太可能在无状态重置数据包中将QUIC位设置为`0`。
+终端在不了解对端是否支持本扩展的情况下**必须不**将QUIC位设置为`0`。
+由于无状态重置数据包（详见《[QUIC]()》的[第10.3章]()）仅会在连接状态丢失后才被使用，所以终端不太可能在无状态重置数据包中将QUIC位设置为`0`。

--- a/3_The_Grease_QUIC_Bit_Transport_Parameter/3.1_Clearing_the_QUIC_Bit.md
+++ b/3_The_Grease_QUIC_Bit_Transport_Parameter/3.1_Clearing_the_QUIC_Bit.md
@@ -7,7 +7,7 @@ rank: "h2"
 
 Endpoints that receive the grease_quic_bit transport parameter from a peer SHOULD set the QUIC Bit to an unpredictable value unless another extension assigns specific meaning to the value of the bit.
 
-从对端接收到传输参数`grease_quic_bit`的终端**应该**将QUIC位设置为不可预测的值，除非另一个扩展为该比特位的值指定了特定的含义。
+从对端接收到传输参数`grease_quic_bit`的终端{{< req_level SHOULD >}}将QUIC位设置为不可预测的值，除非另一个扩展为该比特位的值指定了特定的含义。
 
 Endpoints can set the QUIC Bit to 0 on all packets that are sent after receiving and processing transport parameters. This could include Initial, Handshake, and Retry packets.
 
@@ -16,7 +16,7 @@ Endpoints can set the QUIC Bit to 0 on all packets that are sent after receiving
 
 A client MAY also set the QUIC Bit to 0 in Initial, Handshake, or 0-RTT packets that are sent prior to receiving transport parameters from the server. However, a client MUST NOT set the QUIC Bit to 0 unless the Initial packets it sends include a token provided by the server in a NEW_TOKEN frame (Section 19.7 of [QUIC]), received less than 604800 seconds (7 days) prior on a connection where the server also included the grease_quic_bit transport parameter.
 
-客户端还**可以**在从服务器接收到传输参数前就将发送出去的初始数据包、握手数据包或0-RTT数据包的QUIC位设置为`0`。
+客户端还{{< req_level MAY >}}在从服务器接收到传输参数前就将发送出去的初始数据包、握手数据包或0-RTT数据包的QUIC位设置为`0`。
 不过，只有在客户端发送的初始数据包中包含了服务器在**新令牌帧**（详见《[QUIC]()》的[第19.7章]()）中提供的令牌，且这个帧是在过去604800秒（7天）内，在一条服务器使用了传输参数`grease_quic_bit`的连接上接收到的时，它才可以这么做。
 
 This 7-day limit allows for changes in server configuration. If server configuration changes and a client does not set the QUIC Bit, then it is possible that a server will drop packets, resulting in connection failures.
@@ -26,10 +26,10 @@ This 7-day limit allows for changes in server configuration. If server configura
 
 A server MUST set the QUIC Bit to 0 only after processing transport parameters from a client. A server MUST NOT remember that a client negotiated the extension in a previous connection and set the QUIC Bit to 0 based on that information.
 
-服务器**必须**仅在处理完来自客户端的传输参数后再将QUIC位设置为`0`。
-服务器**必须不**记忆客户端在先前的连接中协商的扩展，或基于该信息来将QUIC位设置为`0`。
+服务器{{< req_level MUST >}}仅在处理完来自客户端的传输参数后再将QUIC位设置为`0`。
+服务器{{< req_level MUST_NOT >}}记忆客户端在先前的连接中协商的扩展，或基于该信息来将QUIC位设置为`0`。
 
 An endpoint MUST NOT set the QUIC Bit to 0 without knowing whether the peer supports the extension. As Stateless Reset packets (Section 10.3 of [QUIC]) are only used after a loss of connection state, endpoints are unlikely to be able to set the QUIC Bit to 0 on Stateless Reset packets.
 
-终端在不了解对端是否支持本扩展的情况下**必须不**将QUIC位设置为`0`。
+终端在不了解对端是否支持本扩展的情况下{{< req_level MUST_NOT >}}将QUIC位设置为`0`。
 由于无状态重置数据包（详见《[QUIC]()》的[第10.3章]()）仅会在连接状态丢失后才被使用，所以终端不太可能在无状态重置数据包中将QUIC位设置为`0`。

--- a/3_The_Grease_QUIC_Bit_Transport_Parameter/3.1_Clearing_the_QUIC_Bit.md
+++ b/3_The_Grease_QUIC_Bit_Transport_Parameter/3.1_Clearing_the_QUIC_Bit.md
@@ -5,31 +5,19 @@ weight: 310
 rank: "h2"
 ---
 
-Endpoints that receive the grease_quic_bit transport parameter from a peer SHOULD set the QUIC Bit to an unpredictable value unless another extension assigns specific meaning to the value of the bit.
-
 从对端接收到传输参数`grease_quic_bit`的终端{{< req_level SHOULD >}}将QUIC位设置为不可预测的值，除非另一个扩展为该比特位的值指定了特定的含义。
-
-Endpoints can set the QUIC Bit to 0 on all packets that are sent after receiving and processing transport parameters. This could include Initial, Handshake, and Retry packets.
 
 终端可以将所有在接收并处理完传输参数后发送的数据包的QUIC位设置为`0`。
 其中可能包括初始数据包、握手数据包和重试数据包。
 
-A client MAY also set the QUIC Bit to 0 in Initial, Handshake, or 0-RTT packets that are sent prior to receiving transport parameters from the server. However, a client MUST NOT set the QUIC Bit to 0 unless the Initial packets it sends include a token provided by the server in a NEW_TOKEN frame (Section 19.7 of [QUIC]), received less than 604800 seconds (7 days) prior on a connection where the server also included the grease_quic_bit transport parameter.
-
 客户端还{{< req_level MAY >}}在从服务器接收到传输参数前就将发送出去的初始数据包、握手数据包或0-RTT数据包的QUIC位设置为`0`。
 不过，只有在客户端发送的初始数据包中包含了服务器在**新令牌帧**（详见《[QUIC]()》的[第19.7章]()）中提供的令牌，且这个帧是在过去604800秒（7天）内，在一条服务器使用了传输参数`grease_quic_bit`的连接上接收到的时，它才可以这么做。
-
-This 7-day limit allows for changes in server configuration. If server configuration changes and a client does not set the QUIC Bit, then it is possible that a server will drop packets, resulting in connection failures.
 
 这个7天的时限容许服务器的配置发生变化。
 如果服务器改变了配置且客户端没有设置QUIC位，那么服务器有可能丢弃数据包，使得连接失败。
 
-A server MUST set the QUIC Bit to 0 only after processing transport parameters from a client. A server MUST NOT remember that a client negotiated the extension in a previous connection and set the QUIC Bit to 0 based on that information.
-
 服务器{{< req_level MUST >}}仅在处理完来自客户端的传输参数后再将QUIC位设置为`0`。
 服务器{{< req_level MUST_NOT >}}记忆客户端在先前的连接中协商的扩展，或基于该信息来将QUIC位设置为`0`。
-
-An endpoint MUST NOT set the QUIC Bit to 0 without knowing whether the peer supports the extension. As Stateless Reset packets (Section 10.3 of [QUIC]) are only used after a loss of connection state, endpoints are unlikely to be able to set the QUIC Bit to 0 on Stateless Reset packets.
 
 终端在不了解对端是否支持本扩展的情况下{{< req_level MUST_NOT >}}将QUIC位设置为`0`。
 由于无状态重置数据包（详见《[QUIC]()》的[第10.3章]()）仅会在连接状态丢失后才被使用，所以终端不太可能在无状态重置数据包中将QUIC位设置为`0`。

--- a/3_The_Grease_QUIC_Bit_Transport_Parameter/3.1_Clearing_the_QUIC_Bit.md
+++ b/3_The_Grease_QUIC_Bit_Transport_Parameter/3.1_Clearing_the_QUIC_Bit.md
@@ -1,0 +1,30 @@
+---
+title: "3. 清除QUIC位"
+anchor: "3.1_Clearing_the_QUIC_Bit"
+weight: 310
+rank: "h2"
+---
+
+Endpoints that receive the grease_quic_bit transport parameter from a peer SHOULD set the QUIC Bit to an unpredictable value unless another extension assigns specific meaning to the value of the bit.
+
+从对端接收到传输参数`grease_quic_bit`的终端**应该**将QUIC位设置为不可预测的值，除非另一个扩展为该比特位的值指定了特定的含义。
+
+Endpoints can set the QUIC Bit to 0 on all packets that are sent after receiving and processing transport parameters. This could include Initial, Handshake, and Retry packets.
+
+终端可以将所有在接收并处理完传输参数后发送的数据包的QUIC位设置为`0`。其中可能包括初始数据包、握手数据包和重试数据包。
+
+A client MAY also set the QUIC Bit to 0 in Initial, Handshake, or 0-RTT packets that are sent prior to receiving transport parameters from the server. However, a client MUST NOT set the QUIC Bit to 0 unless the Initial packets it sends include a token provided by the server in a NEW_TOKEN frame (Section 19.7 of [QUIC]), received less than 604800 seconds (7 days) prior on a connection where the server also included the grease_quic_bit transport parameter.
+
+客户端还**可以**在从服务器接收到传输参数前就将发送出去的初始数据包、握手数据包或0-RTT数据包的QUIC位设置为`0`。不过，只有在客户端发送的初始数据包中包含了服务器在**新令牌帧**（详见《[QUIC]()》的[第19.7章]()）中提供的令牌，且这个帧是在过去604800秒（7天）内，在一条服务器使用了传输参数`grease_quic_bit`的连接上接收到的时，它才可以这么做。
+
+This 7-day limit allows for changes in server configuration. If server configuration changes and a client does not set the QUIC Bit, then it is possible that a server will drop packets, resulting in connection failures.
+
+这个7天的时限容许服务器的配置发生变化。如果服务器改变了配置且客户端没有设置QUIC位，那么服务器有可能丢弃数据包，使得连接失败。
+
+A server MUST set the QUIC Bit to 0 only after processing transport parameters from a client. A server MUST NOT remember that a client negotiated the extension in a previous connection and set the QUIC Bit to 0 based on that information.
+
+服务器**必须**仅在处理完来自客户端的传输参数后再将QUIC位设置为`0`。服务器**必须不**记忆客户端在先前的连接中协商的扩展，或基于该信息来将QUIC位设置为`0`。
+
+An endpoint MUST NOT set the QUIC Bit to 0 without knowing whether the peer supports the extension. As Stateless Reset packets (Section 10.3 of [QUIC]) are only used after a loss of connection state, endpoints are unlikely to be able to set the QUIC Bit to 0 on Stateless Reset packets.
+
+终端在不了解对端是否支持本扩展的情况下**必须不**将QUIC位设置为`0`。由于无状态重置数据包（详见《[QUIC]()》的[第10.3章]()）仅会在连接状态丢失后才被使用，所以终端不太可能在无状态重置数据包中将QUIC位设置为`0`。

--- a/3_The_Grease_QUIC_Bit_Transport_Parameter/3.2_Using_the_QUIC_Bit.md
+++ b/3_The_Grease_QUIC_Bit_Transport_Parameter/3.2_Using_the_QUIC_Bit.md
@@ -13,7 +13,7 @@ Extensions to QUIC that define semantics for the QUIC Bit can be negotiated at t
 
 可以在协商传输参数`grease_quic_bit`的同时协商是否使用为QUIC位定义语义的QUIC扩展。
 在这种情况下，接收方需要有能力分辨随机值和按照扩展传递信息的值。
-使用QUIC位的扩展**必须**在使用值的语义前先协商它们的用途。
+使用QUIC位的扩展{{< req_level MUST >}}在使用值的语义前先协商它们的用途。
 
 For example, an extension might define a transport parameter that is sent in addition to the grease_quic_bit transport parameter. Though the value of the QUIC Bit in packets received by a peer might be set according to rules defined by the extension, they might also be randomized as specified in this document.
 

--- a/3_The_Grease_QUIC_Bit_Transport_Parameter/3.2_Using_the_QUIC_Bit.md
+++ b/3_The_Grease_QUIC_Bit_Transport_Parameter/3.2_Using_the_QUIC_Bit.md
@@ -5,27 +5,17 @@ weight: 320
 rank: "h2"
 ---
 
-The purpose of this extension is to allow for the use of the QUIC Bit by later extensions.
-
 本扩展的目的是允许QUIC位被用于将来的扩展中。
-
-Extensions to QUIC that define semantics for the QUIC Bit can be negotiated at the same time as the grease_quic_bit transport parameter. In this case, a recipient needs to be able to distinguish a randomized value from a value carrying information according to the extension. Extensions that use the QUIC Bit MUST negotiate their use prior to acting on any semantic.
 
 可以在协商传输参数`grease_quic_bit`的同时协商是否使用为QUIC位定义语义的QUIC扩展。
 在这种情况下，接收方需要有能力分辨随机值和按照扩展传递信息的值。
 使用QUIC位的扩展{{< req_level MUST >}}在使用值的语义前先协商它们的用途。
 
-For example, an extension might define a transport parameter that is sent in addition to the grease_quic_bit transport parameter. Though the value of the QUIC Bit in packets received by a peer might be set according to rules defined by the extension, they might also be randomized as specified in this document.
-
 例如，某扩展可能定义一个与传输参数`grease_quic_bit`一起发送的另一个传输参数。
 尽管对端接收到的数据包中的QUIC位可能一开始是按照扩展定义的规则来设置的，但在发送前它们可能按照本文档的规定经过了随机化。
 
-The receipt of a transport parameter for an extension that uses the QUIC Bit could be used to confirm that a peer supports the semantic defined in the extension. To avoid acting on a randomized signal, the extension can require that endpoints set the QUIC Bit according to the rules of the extension but defer acting on the information conveyed until the transport parameter for the extension is received.
-
 如果终端接收到了某使用了QUIC位的扩展所定义的传输参数，那么它就能确信对端支持扩展中定义的语义。
 为了避免对随机值作出反应，扩展可以要求终端按照扩展的规则来设置QUIC位，但是推迟对传递的信息做出反应，直到接收到该扩展定义的传输参数。
-
-Extensions that define semantics for the QUIC Bit can be negotiated without using the grease_quic_bit transport parameter. However, including both extensions allows for the QUIC Bit to be greased even if the alternative use is not supported.
 
 可以不使用传输参数`grease_quic_bit`来协商是否使用为QUIC位定义语义的扩展。
 然而，同时使用这两种扩展使得QUIC位能在其替代用途不受支持的情况下仍能得到转义。

--- a/3_The_Grease_QUIC_Bit_Transport_Parameter/3.2_Using_the_QUIC_Bit.md
+++ b/3_The_Grease_QUIC_Bit_Transport_Parameter/3.2_Using_the_QUIC_Bit.md
@@ -1,0 +1,26 @@
+---
+title: "3. 使用QUIC位"
+anchor: "3.2_Using_the_QUIC_Bit"
+weight: 320
+rank: "h2"
+---
+
+The purpose of this extension is to allow for the use of the QUIC Bit by later extensions.
+
+本扩展的目的是允许QUIC位被用于将来的扩展中。
+
+Extensions to QUIC that define semantics for the QUIC Bit can be negotiated at the same time as the grease_quic_bit transport parameter. In this case, a recipient needs to be able to distinguish a randomized value from a value carrying information according to the extension. Extensions that use the QUIC Bit MUST negotiate their use prior to acting on any semantic.
+
+可以在协商传输参数`grease_quic_bit`的同时协商是否使用为QUIC位定义语义的QUIC扩展。在这种情况下，接收方需要有能力分辨随机值和按照扩展传递信息的值。使用QUIC位的扩展**必须**在使用值的语义前先协商它们的用途。
+
+For example, an extension might define a transport parameter that is sent in addition to the grease_quic_bit transport parameter. Though the value of the QUIC Bit in packets received by a peer might be set according to rules defined by the extension, they might also be randomized as specified in this document.
+
+例如，某扩展可能定义一个与传输参数`grease_quic_bit`一起发送的另一个传输参数。尽管对端接收到的数据包中的QUIC位可能一开始是按照扩展定义的规则来设置的，但在发送前它们可能按照本文档的规定经过了随机化。
+
+The receipt of a transport parameter for an extension that uses the QUIC Bit could be used to confirm that a peer supports the semantic defined in the extension. To avoid acting on a randomized signal, the extension can require that endpoints set the QUIC Bit according to the rules of the extension but defer acting on the information conveyed until the transport parameter for the extension is received.
+
+如果终端接收到了某使用了QUIC位的扩展所定义的传输参数，那么它就能确信对端支持扩展中定义的语义。为了避免对随机值作出反应，扩展可以要求终端按照扩展的规则来设置QUIC位，但是推迟对传递的信息做出反应，直到接收到该扩展定义的传输参数。
+
+Extensions that define semantics for the QUIC Bit can be negotiated without using the grease_quic_bit transport parameter. However, including both extensions allows for the QUIC Bit to be greased even if the alternative use is not supported.
+
+可以不使用传输参数`grease_quic_bit`来协商是否使用为QUIC位定义语义的扩展。然而，同时使用这两种扩展使得QUIC位能在其替代用途不受支持的情况下仍能得到转义。

--- a/3_The_Grease_QUIC_Bit_Transport_Parameter/3.2_Using_the_QUIC_Bit.md
+++ b/3_The_Grease_QUIC_Bit_Transport_Parameter/3.2_Using_the_QUIC_Bit.md
@@ -11,16 +11,21 @@ The purpose of this extension is to allow for the use of the QUIC Bit by later e
 
 Extensions to QUIC that define semantics for the QUIC Bit can be negotiated at the same time as the grease_quic_bit transport parameter. In this case, a recipient needs to be able to distinguish a randomized value from a value carrying information according to the extension. Extensions that use the QUIC Bit MUST negotiate their use prior to acting on any semantic.
 
-可以在协商传输参数`grease_quic_bit`的同时协商是否使用为QUIC位定义语义的QUIC扩展。在这种情况下，接收方需要有能力分辨随机值和按照扩展传递信息的值。使用QUIC位的扩展**必须**在使用值的语义前先协商它们的用途。
+可以在协商传输参数`grease_quic_bit`的同时协商是否使用为QUIC位定义语义的QUIC扩展。
+在这种情况下，接收方需要有能力分辨随机值和按照扩展传递信息的值。
+使用QUIC位的扩展**必须**在使用值的语义前先协商它们的用途。
 
 For example, an extension might define a transport parameter that is sent in addition to the grease_quic_bit transport parameter. Though the value of the QUIC Bit in packets received by a peer might be set according to rules defined by the extension, they might also be randomized as specified in this document.
 
-例如，某扩展可能定义一个与传输参数`grease_quic_bit`一起发送的另一个传输参数。尽管对端接收到的数据包中的QUIC位可能一开始是按照扩展定义的规则来设置的，但在发送前它们可能按照本文档的规定经过了随机化。
+例如，某扩展可能定义一个与传输参数`grease_quic_bit`一起发送的另一个传输参数。
+尽管对端接收到的数据包中的QUIC位可能一开始是按照扩展定义的规则来设置的，但在发送前它们可能按照本文档的规定经过了随机化。
 
 The receipt of a transport parameter for an extension that uses the QUIC Bit could be used to confirm that a peer supports the semantic defined in the extension. To avoid acting on a randomized signal, the extension can require that endpoints set the QUIC Bit according to the rules of the extension but defer acting on the information conveyed until the transport parameter for the extension is received.
 
-如果终端接收到了某使用了QUIC位的扩展所定义的传输参数，那么它就能确信对端支持扩展中定义的语义。为了避免对随机值作出反应，扩展可以要求终端按照扩展的规则来设置QUIC位，但是推迟对传递的信息做出反应，直到接收到该扩展定义的传输参数。
+如果终端接收到了某使用了QUIC位的扩展所定义的传输参数，那么它就能确信对端支持扩展中定义的语义。
+为了避免对随机值作出反应，扩展可以要求终端按照扩展的规则来设置QUIC位，但是推迟对传递的信息做出反应，直到接收到该扩展定义的传输参数。
 
 Extensions that define semantics for the QUIC Bit can be negotiated without using the grease_quic_bit transport parameter. However, including both extensions allows for the QUIC Bit to be greased even if the alternative use is not supported.
 
-可以不使用传输参数`grease_quic_bit`来协商是否使用为QUIC位定义语义的扩展。然而，同时使用这两种扩展使得QUIC位能在其替代用途不受支持的情况下仍能得到转义。
+可以不使用传输参数`grease_quic_bit`来协商是否使用为QUIC位定义语义的扩展。
+然而，同时使用这两种扩展使得QUIC位能在其替代用途不受支持的情况下仍能得到转义。

--- a/3_The_Grease_QUIC_Bit_Transport_Parameter/_index.md
+++ b/3_The_Grease_QUIC_Bit_Transport_Parameter/_index.md
@@ -7,8 +7,11 @@ rank: "h1"
 
 The grease_quic_bit transport parameter (0x2ab2) is defined for QUIC version 1 [QUIC]. This transport parameter can be sent by both client and server. The transport parameter is sent with an empty value; an endpoint that understands this transport parameter MUST treat receipt of a non-empty value of the transport parameter as a connection error of type TRANSPORT_PARAMETER_ERROR.
 
-传输参数`grease_quic_bit`（值为`0x2ab2`）是为QUIC版本1（详见《[QUIC]()》）定义的。客户端和服务器都可以发送该传输参数。发送该传输参数时将值设置为空；理解该传输参数的终端**必须**将接收到此传输参数且其值为非空的情况视作类型为`TRANSPORT_PARAMETER_ERROR`（传输参数错误）的连接错误。
+传输参数`grease_quic_bit`（值为`0x2ab2`）是为QUIC版本1（详见《[QUIC]()》）定义的。
+客户端和服务器都可以发送该传输参数。
+发送该传输参数时将值设置为空；理解该传输参数的终端**必须**将接收到此传输参数且其值为非空的情况视作类型为`TRANSPORT_PARAMETER_ERROR`（传输参数错误）的连接错误。
 
 An endpoint that advertises the grease_quic_bit transport parameter MUST accept packets with the QUIC Bit set to a value of 0. The QUIC Bit is defined as the second-most significant bit of the first byte of QUIC packets (that is, the value 0x40).
 
-宣告传输参数`grease_quic_bit`的终端**必须**接受QUIC位被设置为`0`的数据包。QUIC位的定义是QUIC数据包的首个字节的第二最高有效位（也就是掩码`0x40`所指示的位）。
+宣告传输参数`grease_quic_bit`的终端**必须**接受QUIC位被设置为`0`的数据包。
+QUIC位的定义是QUIC数据包的首个字节的第二最高有效位（也就是掩码`0x40`所指示的位）。

--- a/3_The_Grease_QUIC_Bit_Transport_Parameter/_index.md
+++ b/3_The_Grease_QUIC_Bit_Transport_Parameter/_index.md
@@ -5,13 +5,9 @@ weight: 300
 rank: "h1"
 ---
 
-The grease_quic_bit transport parameter (0x2ab2) is defined for QUIC version 1 [QUIC]. This transport parameter can be sent by both client and server. The transport parameter is sent with an empty value; an endpoint that understands this transport parameter MUST treat receipt of a non-empty value of the transport parameter as a connection error of type TRANSPORT_PARAMETER_ERROR.
-
 传输参数`grease_quic_bit`（值为`0x2ab2`）是为QUIC版本1（详见《[QUIC]()》）定义的。
 客户端和服务器都可以发送该传输参数。
 发送该传输参数时将值设置为空；理解该传输参数的终端{{< req_level MUST >}}将接收到此传输参数且其值为非空的情况视作类型为`TRANSPORT_PARAMETER_ERROR`（传输参数错误）的连接错误。
-
-An endpoint that advertises the grease_quic_bit transport parameter MUST accept packets with the QUIC Bit set to a value of 0. The QUIC Bit is defined as the second-most significant bit of the first byte of QUIC packets (that is, the value 0x40).
 
 宣告传输参数`grease_quic_bit`的终端{{< req_level MUST >}}接受QUIC位被设置为`0`的数据包。
 QUIC位的定义是QUIC数据包的首个字节的第二最高有效位（也就是掩码`0x40`所指示的位）。

--- a/3_The_Grease_QUIC_Bit_Transport_Parameter/_index.md
+++ b/3_The_Grease_QUIC_Bit_Transport_Parameter/_index.md
@@ -1,0 +1,14 @@
+---
+title: "3. 传输参数：grease_quic_bit"
+anchor: "3_The_Grease_QUIC_Bit_Transport_Parameter"
+weight: 300
+rank: "h1"
+---
+
+The grease_quic_bit transport parameter (0x2ab2) is defined for QUIC version 1 [QUIC]. This transport parameter can be sent by both client and server. The transport parameter is sent with an empty value; an endpoint that understands this transport parameter MUST treat receipt of a non-empty value of the transport parameter as a connection error of type TRANSPORT_PARAMETER_ERROR.
+
+传输参数`grease_quic_bit`（值为`0x2ab2`）是为QUIC版本1（详见《[QUIC]()》）定义的。客户端和服务器都可以发送该传输参数。发送该传输参数时将值设置为空；理解该传输参数的终端**必须**将接收到此传输参数且其值为非空的情况视作类型为`TRANSPORT_PARAMETER_ERROR`（传输参数错误）的连接错误。
+
+An endpoint that advertises the grease_quic_bit transport parameter MUST accept packets with the QUIC Bit set to a value of 0. The QUIC Bit is defined as the second-most significant bit of the first byte of QUIC packets (that is, the value 0x40).
+
+宣告传输参数`grease_quic_bit`的终端**必须**接受QUIC位被设置为`0`的数据包。QUIC位的定义是QUIC数据包的首个字节的第二最高有效位（也就是掩码`0x40`所指示的位）。

--- a/3_The_Grease_QUIC_Bit_Transport_Parameter/_index.md
+++ b/3_The_Grease_QUIC_Bit_Transport_Parameter/_index.md
@@ -9,9 +9,9 @@ The grease_quic_bit transport parameter (0x2ab2) is defined for QUIC version 1 [
 
 传输参数`grease_quic_bit`（值为`0x2ab2`）是为QUIC版本1（详见《[QUIC]()》）定义的。
 客户端和服务器都可以发送该传输参数。
-发送该传输参数时将值设置为空；理解该传输参数的终端**必须**将接收到此传输参数且其值为非空的情况视作类型为`TRANSPORT_PARAMETER_ERROR`（传输参数错误）的连接错误。
+发送该传输参数时将值设置为空；理解该传输参数的终端{{< req_level MUST >}}将接收到此传输参数且其值为非空的情况视作类型为`TRANSPORT_PARAMETER_ERROR`（传输参数错误）的连接错误。
 
 An endpoint that advertises the grease_quic_bit transport parameter MUST accept packets with the QUIC Bit set to a value of 0. The QUIC Bit is defined as the second-most significant bit of the first byte of QUIC packets (that is, the value 0x40).
 
-宣告传输参数`grease_quic_bit`的终端**必须**接受QUIC位被设置为`0`的数据包。
+宣告传输参数`grease_quic_bit`的终端{{< req_level MUST >}}接受QUIC位被设置为`0`的数据包。
 QUIC位的定义是QUIC数据包的首个字节的第二最高有效位（也就是掩码`0x40`所指示的位）。

--- a/4_Security_Considerations/_index.md
+++ b/4_Security_Considerations/_index.md
@@ -1,0 +1,10 @@
+---
+title: "4. 关于安全性的考量"
+anchor: "4_Security_Considerations"
+weight: 400
+rank: "h1"
+---
+
+This document introduces no new security considerations for endpoints or entities that can rely on endpoint cooperation. However, this change makes the task of identifying QUIC more difficult without cooperation of endpoints. This sometimes works counter to the security goals of network operators who rely on network classification to identify threats; see Section 3.1 of [MANAGEABILITY] for a more comprehensive treatment of this topic.
+
+本文档为终端或依赖终端协作的实体引入新的安全风险。然而，该变更使得分辨QUIC的任务在没有终端协作的情况下变得更加困难。这有时与网络运营商依靠网络分类来识别威胁的安全目标背道而驰；有关此话题更全面的分析，详见《[QUIC可管理性]()》的[第3.1章]()。

--- a/4_Security_Considerations/_index.md
+++ b/4_Security_Considerations/_index.md
@@ -7,4 +7,6 @@ rank: "h1"
 
 This document introduces no new security considerations for endpoints or entities that can rely on endpoint cooperation. However, this change makes the task of identifying QUIC more difficult without cooperation of endpoints. This sometimes works counter to the security goals of network operators who rely on network classification to identify threats; see Section 3.1 of [MANAGEABILITY] for a more comprehensive treatment of this topic.
 
-本文档为终端或依赖终端协作的实体引入新的安全风险。然而，该变更使得分辨QUIC的任务在没有终端协作的情况下变得更加困难。这有时与网络运营商依靠网络分类来识别威胁的安全目标背道而驰；有关此话题更全面的分析，详见《[QUIC可管理性]()》的[第3.1章]()。
+本文档为终端或依赖终端协作的实体引入新的安全风险。
+然而，该变更使得分辨QUIC的任务在没有终端协作的情况下变得更加困难。
+这有时与网络运营商依靠网络分类来识别威胁的安全目标背道而驰；有关此话题更全面的分析，详见《[QUIC可管理性]()》的[第3.1章]()。

--- a/4_Security_Considerations/_index.md
+++ b/4_Security_Considerations/_index.md
@@ -5,8 +5,6 @@ weight: 400
 rank: "h1"
 ---
 
-This document introduces no new security considerations for endpoints or entities that can rely on endpoint cooperation. However, this change makes the task of identifying QUIC more difficult without cooperation of endpoints. This sometimes works counter to the security goals of network operators who rely on network classification to identify threats; see Section 3.1 of [MANAGEABILITY] for a more comprehensive treatment of this topic.
-
 本文档为终端或依赖终端协作的实体引入新的安全风险。
 然而，该变更使得分辨QUIC的任务在没有终端协作的情况下变得更加困难。
 这有时与网络运营商依靠网络分类来识别威胁的安全目标背道而驰；有关此话题更全面的分析，详见《[QUIC可管理性]()》的[第3.1章]()。

--- a/5_IANA_Considerations/_index.md
+++ b/5_IANA_Considerations/_index.md
@@ -1,0 +1,66 @@
+---
+title: "5. 关于IANA的考量"
+anchor: "5_IANA_Considerations"
+weight: 500
+rank: "h1"
+---
+
+This document registers the grease_quic_bit transport parameter in the "QUIC Transport Parameters" registry established in Section 22.3 of [QUIC]. The following fields are registered:
+
+本文档在《[QUIC]()》的[第22.3章]()定义的注册表《QUIC传输参数》中注册了传输参数`grease_quic_bit`。注册字段如下：
+
+Value:
+0x2ab2
+
+值：
+
+:   `0x2ab2`
+
+Parameter Name:
+grease_quic_bit
+
+参数名称：
+
+:   `grease_quic_bit`
+
+Status:
+Permanent
+
+状态：
+
+:   永久
+
+Specification:
+RFC 9287
+
+规范：
+
+:   RFC 9287
+
+Date:
+2022-07-13
+
+日期：
+
+:   2022-07-13
+
+Change Controller:
+IETF (iesg@ietf.org)
+
+更改责任人：
+
+:   IETF ([iesg@ietf.org](mailto:iesg@ietf.org))
+
+Contact:
+QUIC Working Group (quic@ietf.org)
+
+联系方式：
+
+:   QUIC工作组 ([quic@ietf.org](mailto:quic@ietf.org))
+
+Notes:
+(none)
+
+备注：
+
+:   （无）

--- a/5_IANA_Considerations/_index.md
+++ b/5_IANA_Considerations/_index.md
@@ -5,62 +5,36 @@ weight: 500
 rank: "h1"
 ---
 
-This document registers the grease_quic_bit transport parameter in the "QUIC Transport Parameters" registry established in Section 22.3 of [QUIC]. The following fields are registered:
-
 本文档在《[QUIC]()》的[第22.3章]()定义的注册表《QUIC传输参数》中注册了传输参数`grease_quic_bit`。
 注册字段如下：
-
-Value:
-0x2ab2
 
 值：
 
 :   `0x2ab2`
 
-Parameter Name:
-grease_quic_bit
-
 参数名称：
 
 :   `grease_quic_bit`
-
-Status:
-Permanent
 
 状态：
 
 :   永久
 
-Specification:
-RFC 9287
-
 规范：
 
 :   RFC 9287
-
-Date:
-2022-07-13
 
 日期：
 
 :   2022-07-13
 
-Change Controller:
-IETF (iesg@ietf.org)
-
 更改责任人：
 
 :   IETF ([iesg@ietf.org](mailto:iesg@ietf.org))
 
-Contact:
-QUIC Working Group (quic@ietf.org)
-
 联系方式：
 
 :   QUIC工作组 ([quic@ietf.org](mailto:quic@ietf.org))
-
-Notes:
-(none)
 
 备注：
 

--- a/5_IANA_Considerations/_index.md
+++ b/5_IANA_Considerations/_index.md
@@ -7,7 +7,8 @@ rank: "h1"
 
 This document registers the grease_quic_bit transport parameter in the "QUIC Transport Parameters" registry established in Section 22.3 of [QUIC]. The following fields are registered:
 
-本文档在《[QUIC]()》的[第22.3章]()定义的注册表《QUIC传输参数》中注册了传输参数`grease_quic_bit`。注册字段如下：
+本文档在《[QUIC]()》的[第22.3章]()定义的注册表《QUIC传输参数》中注册了传输参数`grease_quic_bit`。
+注册字段如下：
 
 Value:
 0x2ab2

--- a/6_References/6.1_Normative_References.md
+++ b/6_References/6.1_Normative_References.md
@@ -1,0 +1,22 @@
+---
+title: "6.1. 规范性参考文献"
+anchor: "6.1_Normative_References"
+weight: 610
+rank: "h2"
+---
+
+{{% out_ref ref="QUIC" translation="" %}}
+Iyengar, J., Ed. and M. Thomson, Ed., "QUIC: A UDP-Based Multiplexed and Secure Transport", RFC 9000, DOI 10.17487/RFC9000, May 2021, <https://www.rfc-editor.org/info/rfc9000>.
+{{% /out_ref %}}
+
+{{% out_ref ref="QUIC-INVARIANTS" translation="" %}}
+Thomson, M., "Version-Independent Properties of QUIC", RFC 8999, DOI 10.17487/RFC8999, May 2021, <https://www.rfc-editor.org/info/rfc8999>.
+{{% /out_ref %}}
+
+{{% out_ref ref="RFC2119" translation="" %}}
+Bradner, S., "Key words for use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997, <https://www.rfc-editor.org/info/rfc2119>.
+{{% /out_ref %}}
+
+{{% out_ref ref="RFC8174" translation="" %}}
+Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174, May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+{{% /out_ref %}}

--- a/6_References/6.2_Informative_References.md
+++ b/6_References/6.2_Informative_References.md
@@ -1,0 +1,22 @@
+---
+title: "6.2. 资料性参考文献"
+anchor: "6.2_Informative_References"
+weight: 620
+rank: "h2"
+---
+
+{{% out_ref ref="DEMUX" translation="" %}}
+Aboba, B., Salgueiro, G., and C. Perkins, "Multiplexing Scheme Updates for QUIC", Work in Progress, Internet-Draft, draft-ietf-avtcore-rfc7983bis-06, 5 August 2022, <https://datatracker.ietf.org/doc/html/draft-ietf-avtcore-rfc7983bis-06>.
+{{% /out_ref %}}
+
+{{% out_ref ref="MANAGEABILITY" translation="" %}}
+Kuehlewind, M. and B. Trammell, "Manageability of the QUIC Transport Protocol", Work in Progress, Internet-Draft, draft-ietf-quic-manageability-18, 15 July 2022, <https://datatracker.ietf.org/doc/html/draft-ietf-quic-manageability-18>.
+{{% /out_ref %}}
+
+{{% out_ref ref="RFC8546" translation="" %}}
+Trammell, B. and M. Kuehlewind, "The Wire Image of a Network Protocol", RFC 8546, DOI 10.17487/RFC8546, April 2019, <https://www.rfc-editor.org/info/rfc8546>.
+{{% /out_ref %}}
+
+{{% out_ref ref="USE-IT" translation="" %}}
+Thomson, M. and T. Pauly, "Long-Term Viability of Protocol Extension Mechanisms", RFC 9170, DOI 10.17487/RFC9170, December 2021, <https://www.rfc-editor.org/info/rfc9170>.
+{{% /out_ref %}}

--- a/6_References/_index.md
+++ b/6_References/_index.md
@@ -1,0 +1,6 @@
+---
+title: "6. 参考文献"
+anchor: "6_References"
+weight: 600
+rank: "h1"
+---

--- a/Authors_Addresses/_index.md
+++ b/Authors_Addresses/_index.md
@@ -1,0 +1,23 @@
+---
+title: "联系作者"
+anchor: "Authors_Addresses"
+weight: 700
+rank: "h1"
+---
+
+##### Martin Thomson
+
+Mozilla
+
+Email: [mt@lowentropy.net](mailto:mt@lowentropy.net)
+
+## 译
+
+- [Yunzhe](https://github.com/YunzheZJU)
+    - Email: yunzhe@zju.edu.cn
+
+- [ruokeqx](https://github.com/ruokeqx)
+    - Email: ruokeqx@163.com
+
+- [方秋航](https://github.com/fangqiuhang)
+    - Email: fangqiuhang@163.com

--- a/Foreword/_index.md
+++ b/Foreword/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "RFC9287 QUIC位传输"
-anchor: "RFC9287\_Greasing\_the\_QUIC\_Bit"
+title: "RFC9287 QUIC位转义"
+anchor: "RFC9287_Greasing_the_QUIC_Bit"
 weight: 1
 ---
 

--- a/Foreword/abstract.md
+++ b/Foreword/abstract.md
@@ -5,6 +5,4 @@ weight: 10
 rank: "h2"
 ---
 
-This document describes a method for negotiating the ability to send an arbitrary value for the second-most significant bit in QUIC packets.
-
 本文档描述了一种方法，使用此方法能够协商是否在QUIC数据包中的第二最高有效位上传输任意值。

--- a/Foreword/abstract.md
+++ b/Foreword/abstract.md
@@ -5,4 +5,6 @@ weight: 10
 rank: "h2"
 ---
 
-本文描述了一种协商能够为QUIC包第二个重要位发送任意值的能力的方法。
+This document describes a method for negotiating the ability to send an arbitrary value for the second-most significant bit in QUIC packets.
+
+本文档描述了一种方法，使用此方法能够协商是否在QUIC数据包中的第二最高有效位上传输任意值。

--- a/_index.md
+++ b/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "RFC9287中文：QUIC位传输"
+title: "RFC9287中文：QUIC位转义"
 anchor: "RFC9287"
 weight: 400
 rank: "sub_page"


### PR DESCRIPTION
译为《QUIC位转义》，是在翻译3_The_Grease_QUIC_Bit_Transport_Parameter/3.2_Using_the_QUIC_Bit.md的最后一句时想到的。grease本意是润滑，上油，实际这个传输参数的用途是确保QUIC位的语义不被规范的定义限制住，起“转义”的作用，至于转成什么“义”，则由其他扩展自由指定。
